### PR TITLE
RFF: Add an extend-method to have external modules hook into annotations, to e.g. prevent "virtual" fields from being build.

### DIFF
--- a/code/Generators/AbstractTagGenerator.php
+++ b/code/Generators/AbstractTagGenerator.php
@@ -171,7 +171,21 @@ abstract class AbstractTagGenerator
      */
     protected function getClassConfig($key)
     {
-        return Config::inst()->get($this->className, $key, Config::UNINHERITED);
+        $config = Config::inst()->get($this->className, $key, Config::UNINHERITED);
+        if($config && $key == 'db') {
+            // If we use Fluent, it's better to not document translated fields
+            if(class_exists('Fluent')) {
+                $translatedFields = FluentExtension::translated_fields_for($this->className);
+                if(!empty($translatedFields)) {
+                    $extraConfig = FluentExtension::generate_extra_config($this->className);
+                    if(!empty($extraConfig['db'])) {
+                        $config = array_diff($config, $extraConfig['db']);
+                    }
+                    $config = array_merge($config,$translatedFields);
+                }
+            }
+        }
+        return $config;
     }
 
     /**


### PR DESCRIPTION
Fluent add extra fields for translations, but they are never used (the main field is called, and it's magically translated). Therefore, there is no need to document these fields.